### PR TITLE
:bug: fix/fastapi docs register_hint Function internal wrapper class not register in fastapi model_name_name

### DIFF
--- a/cfcreator/control.py
+++ b/cfcreator/control.py
@@ -263,6 +263,7 @@ def register_hint(
 
     class _(IAlgorithm):
         model_class = _Model
+        model_class.__name__ = hint_model_class.__name__
 
         endpoint = hint_endpoint
 


### PR DESCRIPTION
[fix fastapi openapi.json error](https://github.com/carefree0910/carefree-creator/issues/25)